### PR TITLE
Fix typos in comment blocks

### DIFF
--- a/src/Console/Command/I18nCsvDiffCommand.php
+++ b/src/Console/Command/I18nCsvDiffCommand.php
@@ -3,7 +3,7 @@
  * Hyvä Themes - https://hyva.io
  * Copyright © Hyvä Themes 2021-present. All rights reserved.
  * This product is licensed under the terms of the BSD-3-Clause license.
- * See the LICENSE.txt fi,e for more information.
+ * See the LICENSE.txt file for more information.
  */
 
 declare(strict_types=1);

--- a/src/Console/Command/I18nCsvTranslateCommand.php
+++ b/src/Console/Command/I18nCsvTranslateCommand.php
@@ -3,7 +3,7 @@
  * Hyvä Themes - https://hyva.io
  * Copyright © Hyvä Themes 2021-present. All rights reserved.
  * This product is licensed under the terms of the BSD-3-Clause license.
- * See the LICENSE.txt fi,e for more information.
+ * See the LICENSE.txt file for more information.
  */
 
 declare(strict_types=1);

--- a/src/registration.php
+++ b/src/registration.php
@@ -3,7 +3,7 @@
  * Hyvä Themes - https://hyva.io
  * Copyright © Hyvä Themes 2021-present. All rights reserved.
  * This product is licensed under the terms of the BSD-3-Clause license.
- * See the LICENSE.txt fi,e for more information.
+ * See the LICENSE.txt file for more information.
  */
 
 declare(strict_types=1);


### PR DESCRIPTION
Correct spelling mistakes in comments.

* **src/Console/Command/I18nCsvDiffCommand.php**
  - Correct "fi,e" to "file" in the comment block.

* **src/Console/Command/I18nCsvTranslateCommand.php**
  - Correct "fi,e" to "file" in the comment block.

* **src/registration.php**
  - Correct "fi,e" to "file" in the comment block.

